### PR TITLE
Move save all button and increase its size

### DIFF
--- a/src/components/Distribute.js
+++ b/src/components/Distribute.js
@@ -43,12 +43,12 @@ export default class Distribute extends Component {
     return (
       <div className="container distribute-container flex-column">
         <Panel title="Secret Shares">
-          <SaveAllButton type="small"
-            contents={shares}
-            onSavedAll={this.onSavedAll.bind(this)} />
           <div className="shares-table">
             {shareRows}
           </div>
+          <SaveAllButton
+            contents={shares}
+            onSavedAll={this.onSavedAll.bind(this)} />
         </Panel>
         <Info>
           {`Remember: you need ${quorum} out of ${shares.length} shares to recover the secret.`}


### PR DESCRIPTION
Hi @koenaad. This change places the save all button below the share list and make it default size per conversation on freedomofpress/sunder#133. I decided not to invert the colors or change the button width in order to make the change simpler and keep button styles consistent throughout the app.

Could you review and merge this into your branch? That should automatically update your PR on the main fork.
